### PR TITLE
Feat: Exports for Gizmo

### DIFF
--- a/client/nui.lua
+++ b/client/nui.lua
@@ -694,16 +694,8 @@ RegisterNUICallback('dolu_tool:setDrawStaticEmitters', function(state, cb)
     Client.drawStaticEmitters = state
 end)
 
-
-
-
--- NUI exports
-
-
----Export for setting an entity to be Gizmo controlled
----@param v Number
+-- Exports
 exports("setGizmoEntity", function(obj)
-    print("Setting gizmo entity to: ", obj )
     Client.gizmoEntity = obj
     SendNUIMessage({
         action = 'setGizmoEntity',
@@ -718,8 +710,6 @@ exports("setGizmoEntity", function(obj)
     SetNuiFocusKeepInput(true)
 end)
 
-
----Export for setting the gizmo entity to nothing
 exports("removeGizmoEntity", function()
     SendNUIMessage({
         action = 'setGizmoEntity',

--- a/client/nui.lua
+++ b/client/nui.lua
@@ -693,3 +693,39 @@ RegisterNUICallback('dolu_tool:setDrawStaticEmitters', function(state, cb)
     cb(1)
     Client.drawStaticEmitters = state
 end)
+
+
+
+
+-- NUI exports
+
+
+---Export for setting an entity to be Gizmo controlled
+---@param v Number
+exports("setGizmoEntity", function(obj)
+    print("Setting gizmo entity to: ", obj )
+    Client.gizmoEntity = obj
+    SendNUIMessage({
+        action = 'setGizmoEntity',
+        data = {
+            name = modelName,
+            handle = obj,
+            position = GetEntityCoords(obj),
+            rotation = GetEntityRotation(obj),
+        }
+    })
+    SetNuiFocus(true, true)
+    SetNuiFocusKeepInput(true)
+end)
+
+
+---Export for setting the gizmo entity to nothing
+exports("removeGizmoEntity", function()
+    SendNUIMessage({
+        action = 'setGizmoEntity',
+        data = {}
+    })
+    Client.gizmoEntity = nil
+    SetNuiFocus(false, false)
+    SetNuiFocusKeepInput(false)
+end)


### PR DESCRIPTION
This means that other resources will be free to use the three.js UI for moving the entities, this would be handy for housing resources and more.