### PR TITLE
ref(client): remove entity if doesn’t exist (in game world)

### DIFF
--- a/client/nui.lua
+++ b/client/nui.lua
@@ -535,7 +535,7 @@ end)
 RegisterNUICallback('dolu_tool:deleteEntity', function(entityHandle, cb)
     cb(1)
 
-    if not Client.spawnedEntities[entityHandle] or not DoesEntityExist(entityHandle) then
+    if not Client.spawnedEntities[entityHandle] then
         lib.notify({
             title = 'Dolu Tool',
             description = locale('entity_doesnt_exist'),


### PR DESCRIPTION
The reason why deletion shouldn’t be prohibited is that when an anticheat (such as fiveguard’s objects-ai) or another resource removes this object, it will still remain on the list, without any way of deleting it.