### PR TITLE
feat(input): prevent keybinds from firing while typing in input fields

### DIFF
--- a/client/commands.lua
+++ b/client/commands.lua
@@ -2,7 +2,8 @@ lib.addKeybind({
     name = 'dolu_tool:open',
     description = locale('command_openui', '~b~>~w~'),
     defaultKey = Config.openMenuKey,
-    onPressed = function(self)
+    onPressed = function()
+        if Client.inputFocused then return end
         if Config.usePermission and not lib.callback.await('dolu_tool:isAllowed', 100, true) then return end
 
         if not IsNuiFocused() and not IsPauseMenuActive() then
@@ -18,7 +19,8 @@ lib.addKeybind({
     name = 'tpm',
     description = locale('command_tpm', '~b~>~w~'),
     defaultKey = Config.teleportMarkerKey,
-    onPressed = function(self)
+    onPressed = function()
+        if Client.inputFocused then return end
         if Config.usePermission and not lib.callback.await('dolu_tool:isAllowed', 100, true) then return end
 
         local marker = GetFirstBlipInfoId(8)
@@ -84,7 +86,8 @@ lib.addKeybind({
     name = 'noclip',
     description = locale('command_noclip', '~b~>~w~'),
     defaultKey = Config.toggleNoclipKey,
-    onPressed = function(self)
+    onPressed = function()
+        if Client.inputFocused then return end
         if Config.usePermission and not lib.callback.await('dolu_tool:isAllowed', 100, true) then return end
 
         Client.noClip = not Client.noClip
@@ -93,6 +96,7 @@ lib.addKeybind({
 })
 
 RegisterCommand('goback', function()
+    if Client.inputFocused then return end
     if Config.usePermission and not lib.callback.await('dolu_tool:isAllowed', 100, true) then return end
 
     if not Client.lastCoords then

--- a/client/nui.lua
+++ b/client/nui.lua
@@ -95,10 +95,19 @@ RegisterNUICallback('dolu_tool:deleteVehicle', function(_, cb)
     end
 end)
 
+RegisterNUICallback('dolu_tool:setInputFocus', function(keepGameInput, cb)
+    cb(1)
+    Client.inputFocused = not keepGameInput -- true when typing in input
+    if Client.isMenuOpen then
+        SetNuiFocusKeepInput(keepGameInput)
+    end
+end)
+
 RegisterNUICallback('dolu_tool:exit', function(_, cb)
     cb(1)
     SetNuiFocus(false, false)
     SetNuiFocusKeepInput(false)
+    Client.inputFocused = false
 
     SendNUIMessage({
         action = 'setGizmoEntity',

--- a/shared/init.lua
+++ b/shared/init.lua
@@ -36,6 +36,7 @@ elseif lib.context == 'client' then
     Client = {
         noClip = false,
         isMenuOpen = false,
+        inputFocused = false,
         currentTab = 'home',
         lastLocation = json.decode(GetResourceKvpString('dolu_tool:lastLocation')),
         portalPoly = false,

--- a/web/src/layouts/gizmo/TransformComponent.tsx
+++ b/web/src/layouts/gizmo/TransformComponent.tsx
@@ -49,20 +49,27 @@ export const TransformComponent = React.memo(({ space, mode, currentEntity, setC
   }, []);
 
   const handleObjectDataUpdate = useCallback((): void => {
-    // Just send position/rotation, let Lua decide what to do
-    fetchNui('dolu_tool:updateGizmoTransform', {
-      position: {
-        x: mesh.current.position.x,
-        y: -mesh.current.position.z,
-        z: mesh.current.position.y
-      },
-      rotation: {
-        x: MathUtils.radToDeg(mesh.current.rotation.x),
-        y: MathUtils.radToDeg(-mesh.current.rotation.z),
-        z: MathUtils.radToDeg(mesh.current.rotation.y)
-      }
-    });
-  }, [mesh]);
+    const position = {
+      x: mesh.current.position.x,
+      y: -mesh.current.position.z,
+      z: mesh.current.position.y
+    };
+    const rotation = {
+      x: MathUtils.radToDeg(mesh.current.rotation.x),
+      y: MathUtils.radToDeg(-mesh.current.rotation.z),
+      z: MathUtils.radToDeg(mesh.current.rotation.y)
+    };
+
+    fetchNui('dolu_tool:updateGizmoTransform', { position, rotation });
+
+    if (currentEntity) {
+      setCurrentEntity({
+        ...currentEntity,
+        position: position as TransformEntity['position'],
+        rotation: rotation as TransformEntity['rotation']
+      });
+    }
+  }, [mesh, currentEntity, setCurrentEntity]);
 
   const handleMouseDown = useCallback(() => {
     onMouseDown?.()

--- a/web/src/layouts/gizmo/TransformComponent.tsx
+++ b/web/src/layouts/gizmo/TransformComponent.tsx
@@ -6,7 +6,7 @@ import { useNuiEvent } from '../../hooks/useNuiEvent'
 import { fetchNui } from '../../utils/fetchNui'
 import { RotateSnapAtom, TranslateSnapAtom } from '../../atoms/object'
 
-export const TransformComponent = React.memo(({ space, mode, currentEntity, setCurrentEntity, onMouseUp, onMouseDown }: TransformComponent) => {
+export const TransformComponent = React.memo(({ space, mode, currentEntity, setCurrentEntity, onMouseUp, onMouseDown }: TransformComponentProps) => {
   const mesh = useRef<Mesh>(null!);
   const translateSnap = useRecoilValue(TranslateSnapAtom);
   const rotateSnap = useRecoilValue(RotateSnapAtom);
@@ -62,14 +62,16 @@ export const TransformComponent = React.memo(({ space, mode, currentEntity, setC
 
     fetchNui('dolu_tool:updateGizmoTransform', { position, rotation });
 
-    if (currentEntity) {
-      setCurrentEntity({
-        ...currentEntity,
-        position: position as TransformEntity['position'],
-        rotation: rotation as TransformEntity['rotation']
-      });
-    }
-  }, [mesh, currentEntity, setCurrentEntity]);
+    setCurrentEntity((prev) =>
+      prev
+        ? {
+          ...prev,
+          position: position as TransformEntity['position'],
+          rotation: rotation as TransformEntity['rotation']
+        }
+        : prev
+    );
+  }, [mesh, setCurrentEntity]);
 
   const handleMouseDown = useCallback(() => {
     onMouseDown?.()

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -25,10 +25,16 @@ interface ModeSelector {
   currentEntity: TransformEntity | undefined;
 }
 
-interface TransformComponent extends ModeSelector {
+interface TransformComponentProps extends ModeSelector {
   currentEntity: TransformEntity | undefined;
   onChangeSpace?: () => void;
-  setCurrentEntity: (value: TransformEntity | undefined) => void;
+  /** Matches `useState` setter; supports functional updates for stable callbacks. */
+  setCurrentEntity: (
+    value:
+      | TransformEntity
+      | undefined
+      | ((prev: TransformEntity | undefined) => TransformEntity | undefined),
+  ) => void;
   onChangeMode?: (value: GizmoEditorMode) => void;
 
   onMouseUp?: (e?: THREE.Event) => void;


### PR DESCRIPTION
Added functionality to manage input focus state, ensuring keybinds are disabled when the user is typing. This includes updates to the client commands and NUI callbacks to handle input focus correctly.