### PR TITLE
feat: validate web NUI event payloads

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,8 @@
     "react-icons": "^4.9.0",
     "react-router-dom": "^6.6.2",
     "recoil": "^0.7.6",
-    "three": "^0.145.0"
+    "three": "^0.145.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^16.11.18",
@@ -32,7 +33,7 @@
     "@vitejs/plugin-react": "^1.3.2",
     "cross-env": "^7.0.3",
     "rimraf": "^3.0.2",
-    "typescript": "^4.9.4",
+    "typescript": "^5.9.3",
     "vite": "^2.9.15"
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       three:
         specifier: ^0.145.0
         version: 0.145.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^16.11.18
@@ -70,8 +73,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       typescript:
-        specifier: ^4.9.4
-        version: 4.9.4
+        specifier: ^5.9.3
+        version: 5.9.3
       vite:
         specifier: ^2.9.15
         version: 2.9.15
@@ -584,7 +587,7 @@ packages:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
@@ -798,6 +801,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -826,6 +830,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -871,9 +876,11 @@ packages:
 
   lodash.omit@4.5.0:
     resolution: {integrity: sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==}
+    deprecated: This package is deprecated. Use destructuring assignment syntax instead.
 
   lodash.pick@4.4.0:
     resolution: {integrity: sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==}
+    deprecated: This package is deprecated. Use destructuring assignment syntax instead.
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -1057,6 +1064,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rollup@2.77.3:
@@ -1148,9 +1156,9 @@ packages:
   tslib@2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
 
-  typescript@4.9.4:
-    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
-    engines: {node: '>=4.2.0'}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   update-browserslist-db@1.0.10:
@@ -1222,6 +1230,9 @@ packages:
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zstddec@0.0.2:
     resolution: {integrity: sha512-DCo0oxvcvOTGP/f5FA6tz2Z6wF+FIcEApSTu0zV5sQgn9hoT5lZ9YRAKUraxt9oP7l4e8TnNdi8IZTCX6WCkwA==}
@@ -2313,7 +2324,7 @@ snapshots:
 
   tslib@2.4.1: {}
 
-  typescript@4.9.4: {}
+  typescript@5.9.3: {}
 
   update-browserslist-db@1.0.10(browserslist@4.21.4):
     dependencies:
@@ -2362,6 +2373,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@1.10.2: {}
+
+  zod@4.4.3: {}
 
   zstddec@0.0.2: {}
 

--- a/web/src/atoms/audio.ts
+++ b/web/src/atoms/audio.ts
@@ -1,15 +1,23 @@
 import { SelectItem } from "@mantine/core"
 import { atom } from "recoil"
+import { z } from "zod"
 
-export interface StaticEmitter {
-    name: string
-    coords: string
-    distance: number
-    flags: string
-    interior: string
-    room: string
-    radiostation: string
-}
+export const selectItemSchema = z.object({
+    label: z.string(),
+    value: z.string(),
+})
+
+export const staticEmitterSchema = z.object({
+    name: z.string(),
+    coords: z.string(),
+    distance: z.number(),
+    flags: z.string(),
+    interior: z.string(),
+    room: z.string(),
+    radiostation: z.string(),
+})
+
+export type StaticEmitter = z.infer<typeof staticEmitterSchema>
 
 const mockStaticEmitters: StaticEmitter = {
     name: "collision_75oaiz",

--- a/web/src/atoms/interior.ts
+++ b/web/src/atoms/interior.ts
@@ -1,38 +1,43 @@
 import { atom, selector, useRecoilValue } from 'recoil'
+import { z } from 'zod'
 
-export interface InteriorData {
-    interiorId: number
-    roomCount?: number
-    portalCount?: number
-    rooms?: Array<{
-        index: number
-        name: string
-        timecycle: string
-        isCurrent: boolean
-        flags: {
-            list: string[]
-            total: number
-        }
-    }>
-    portals?: Array<{
-        index: number
-        roomFrom: number
-        roomTo: number
-        flags: {
-            list: string[]
-            total: number
-        }
-    }>
-    currentRoom?: {
-        index: number
-        name: string
-        timecycle: string
-        flags: {
-            list: string[]
-            total: number
-        }
-    }
-}
+export const timecycleOptionSchema = z.object({
+    label: z.string(),
+    value: z.string(),
+})
+
+const flagValueSchema = z.union([z.string(), z.number()]).transform(String)
+
+const interiorFlagsSchema = z.object({
+    list: z.array(flagValueSchema),
+    total: z.number(),
+})
+
+const roomSchema = z.object({
+    index: z.number(),
+    name: z.string(),
+    timecycle: z.string(),
+    isCurrent: z.boolean().optional(),
+    flags: interiorFlagsSchema,
+})
+
+const portalSchema = z.object({
+    index: z.number(),
+    roomFrom: z.number(),
+    roomTo: z.number(),
+    flags: interiorFlagsSchema,
+})
+
+export const interiorDataSchema = z.object({
+    interiorId: z.number(),
+    roomCount: z.number().optional(),
+    portalCount: z.number().optional(),
+    rooms: z.array(roomSchema).optional(),
+    portals: z.array(portalSchema).optional(),
+    currentRoom: roomSchema.omit({ isCurrent: true }).optional(),
+})
+
+export type InteriorData = z.infer<typeof interiorDataSchema>
 
 const mockInterior: InteriorData = {
     interiorId: -1

--- a/web/src/atoms/location.ts
+++ b/web/src/atoms/location.ts
@@ -1,15 +1,24 @@
 import { atom, useRecoilValue } from 'recoil'
+import { z } from 'zod'
 
-export interface Location {
-  name: string,
-  x: number,
-  y: number,
-  z: number,
-  heading?: number,
-  custom?: boolean
-  metadata?: any,
-  isLastLocationUsed?: boolean
-}
+export const locationSchema = z.object({
+  name: z.string(),
+  x: z.number(),
+  y: z.number(),
+  z: z.number(),
+  heading: z.number().optional(),
+  custom: z.boolean().optional(),
+  metadata: z.unknown().optional(),
+  isLastLocationUsed: z.boolean().optional(),
+})
+
+export type Location = z.infer<typeof locationSchema>
+
+export const locationPageContentSchema = z.object({
+  type: z.literal('locations'),
+  content: z.array(locationSchema),
+  maxPages: z.number(),
+})
 
 const mockLocations: Location[] = [
     {

--- a/web/src/atoms/object.ts
+++ b/web/src/atoms/object.ts
@@ -1,24 +1,52 @@
 import { atom, useRecoilValue } from 'recoil'
+import { z } from 'zod'
 
-export interface Entity {
-    id: string
-    handle: number
-    name: string
-    position: {
-        x: number
-        y: number
-        z: number
-    },
-    rotation: {
-        x: number
-        y: number
-        z: number
-    },
-    frozen?: boolean
-    invalid?: boolean
-}
+export const vector3Schema = z.object({
+    x: z.number(),
+    y: z.number(),
+    z: z.number(),
+})
+
+export const entitySchema = z.object({
+    id: z.string().optional(),
+    handle: z.number(),
+    name: z.string(),
+    position: vector3Schema,
+    rotation: vector3Schema,
+    frozen: z.boolean().optional(),
+    invalid: z.boolean().optional(),
+}).transform((entity) => ({
+    ...entity,
+    id: entity.id ?? String(entity.handle),
+}))
+
+export type Entity = z.infer<typeof entitySchema>
 
 export type ObjectList = Array<Entity>
+
+export const objectListPayloadSchema = z.object({
+    entitiesList: z.array(entitySchema).nullable(),
+})
+
+export const objectDataPayloadSchema = z.object({
+    entity: entitySchema,
+})
+
+export const transformEntitySchema = z.object({
+    name: z.string().default(''),
+    hash: z.number().default(0),
+    handle: z.number().default(0),
+    position: vector3Schema,
+    rotation: vector3Schema,
+    id: z.string().optional(),
+})
+
+export const transformEntityPayloadSchema = transformEntitySchema.optional()
+
+export const cameraPositionSchema = z.object({
+    position: vector3Schema,
+    rotation: vector3Schema.optional(),
+})
 
 export const ObjectListAtom = atom<ObjectList>({key: "ObjectList", default: []})
 export const ObjectNameAtom = atom<string>({ key: 'ObjectCurrentAccordionItem', default: 'prop_alien_egg_01' })

--- a/web/src/atoms/ped.ts
+++ b/web/src/atoms/ped.ts
@@ -1,9 +1,18 @@
 import { atom, useRecoilValue } from 'recoil'
+import { z } from 'zod'
 
-export interface PedProp {
-  name: string,
-  hash?: number
-}
+export const pedPropSchema = z.object({
+  name: z.string(),
+  hash: z.number().optional(),
+})
+
+export type PedProp = z.infer<typeof pedPropSchema>
+
+export const pedPageContentSchema = z.object({
+  type: z.literal('peds'),
+  content: z.array(pedPropSchema),
+  maxPages: z.number(),
+})
 
 const mockPedList: PedProp[] = [
     {

--- a/web/src/atoms/position.ts
+++ b/web/src/atoms/position.ts
@@ -1,4 +1,10 @@
 import { atom, useRecoilValue } from 'recoil'
+import { z } from 'zod'
+
+export const playerCoordsSchema = z.object({
+    coords: z.string(),
+    heading: z.string(),
+})
 
 const mockPosition: string = "0, 0, 0"
 

--- a/web/src/atoms/vehicle.ts
+++ b/web/src/atoms/vehicle.ts
@@ -1,14 +1,23 @@
 import { atom, useRecoilValue } from 'recoil'
+import { z } from 'zod'
 
-export interface VehicleProp {
-  hash: number,
-  name: string,
-  class: string,
-  displayName: string,
-  type: string,
-  dlc: string,
-  manufacturer: string,
-}
+export const vehiclePropSchema = z.object({
+  hash: z.number(),
+  name: z.string(),
+  class: z.string(),
+  displayName: z.string(),
+  type: z.string(),
+  dlc: z.string(),
+  manufacturer: z.string(),
+})
+
+export type VehicleProp = z.infer<typeof vehiclePropSchema>
+
+export const vehiclePageContentSchema = z.object({
+  type: z.literal('vehicles'),
+  content: z.array(vehiclePropSchema),
+  maxPages: z.number(),
+})
 
 const mockVehicleList: VehicleProp[] = [
     {

--- a/web/src/atoms/version.ts
+++ b/web/src/atoms/version.ts
@@ -1,8 +1,11 @@
 import { atom } from 'recoil'
+import { z } from 'zod'
 
-export interface Version {
-    currentVersion: string
-    url?: string
-}
+export const versionSchema = z.object({
+    currentVersion: z.string(),
+    url: z.string().optional(),
+})
+
+export type Version = z.infer<typeof versionSchema>
 
 export const versionAtom = atom<Version>({ key: 'version', default: { currentVersion: "" } })

--- a/web/src/atoms/visibility.ts
+++ b/web/src/atoms/visibility.ts
@@ -1,3 +1,14 @@
 import { atom } from 'recoil'
+import { z } from 'zod'
+import { locationSchema } from './location'
+import { versionSchema } from './version'
 
 export const menuVisibilityAtom = atom({ key: 'menuVisibility', default: false })
+
+export const emptyEventSchema = z.unknown()
+
+export const menuVisiblePayloadSchema = z.object({
+    version: versionSchema,
+    lastLocation: locationSchema,
+    position: z.string(),
+})

--- a/web/src/atoms/weapon.ts
+++ b/web/src/atoms/weapon.ts
@@ -1,9 +1,18 @@
 import { atom, useRecoilValue } from 'recoil'
+import { z } from 'zod'
 
-export interface WeaponProp {
-  hash: number,
-  name: string,
-}
+export const weaponPropSchema = z.object({
+  hash: z.number(),
+  name: z.string(),
+})
+
+export type WeaponProp = z.infer<typeof weaponPropSchema>
+
+export const weaponPageContentSchema = z.object({
+  type: z.literal('weapons'),
+  content: z.array(weaponPropSchema),
+  maxPages: z.number(),
+})
 
 const mockWeaponList: WeaponProp[] = [
     {

--- a/web/src/atoms/world.ts
+++ b/web/src/atoms/world.ts
@@ -1,4 +1,15 @@
 import { atom, useRecoilValue } from 'recoil'
+import { z } from 'zod'
+
+export const clockDataSchema = z.object({
+    hour: z.number(),
+    minute: z.number(),
+})
+
+export const worldDataSchema = z.object({
+    weather: z.string(),
+    clock: clockDataSchema,
+})
 
 export const worldHourAtom = atom<number>({ key: 'worldHour', default: 0 })
 export const worldMinuteAtom = atom<number>({ key: 'worldMinute', default: 0 })

--- a/web/src/hooks/useNuiValidatedEvent.ts
+++ b/web/src/hooks/useNuiValidatedEvent.ts
@@ -1,0 +1,52 @@
+import { treeifyError, z } from 'zod'
+import { useNuiEvent } from './useNuiEvent'
+
+interface ZodErrorTree {
+  errors: string[]
+  properties: Record<string, ZodErrorTree>
+  items?: ZodErrorTree[]
+}
+
+const logErrorTree = (node: ZodErrorTree, path: string = '') => {
+  if (node.errors?.length > 0) {
+    node.errors.forEach((msg: string) => {
+      console.log(`[Field: ${path || 'root'}] -> ${msg}`)
+    })
+  }
+
+  if (node.properties) {
+    for (const key in node.properties) {
+      const currentPath = path ? `${path}.${key}` : key
+      if (node.properties[key]) {
+        logErrorTree(node.properties[key], currentPath)
+      }
+    }
+  }
+
+  if (Array.isArray(node.items)) {
+    node.items.forEach((item: ZodErrorTree, index: number) => {
+      logErrorTree(item, `${path}[${index}]`)
+    })
+  }
+}
+
+export function useNuiValidatedEvent<T>(
+  eventName: string,
+  schema: z.ZodSchema<T>,
+  handler: (data: T) => void
+) {
+  useNuiEvent<unknown>(eventName, (rawData: unknown) => {
+    const result = schema.safeParse(rawData)
+
+    if (result.success) {
+      handler(result.data)
+    } else {
+      const errorResult = treeifyError(result.error) as ZodErrorTree
+      console.log(`[Validation Failed] Event: "${eventName}"`)
+      console.log('-------------------------------------------')
+      errorResult.errors?.forEach((err) => console.log(`[Root Error]: ${err}`))
+      logErrorTree(errorResult)
+      console.log('-------------------------------------------')
+    }
+  })
+}

--- a/web/src/layouts/gizmo/CameraComponent.tsx
+++ b/web/src/layouts/gizmo/CameraComponent.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback } from 'react'
 import { PerspectiveCamera } from '@react-three/drei'
-import { useNuiEvent } from '../../hooks/useNuiEvent'
+import { useNuiValidatedEvent } from '../../hooks/useNuiValidatedEvent'
 import { useThree } from '@react-three/fiber'
 import { MathUtils } from 'three'
+import { cameraPositionSchema } from '../../atoms/object'
 
 export const CameraComponent = React.memo(() => {
   const { camera } = useThree()
@@ -11,7 +12,7 @@ export const CameraComponent = React.memo(() => {
     return t > 0 && t < 90 ? e : (t > -180 && t < -90) || t > 0 ? -e : e
   }, []);
 
-  useNuiEvent('setCameraPosition', ({ position, rotation }: any) => {
+  useNuiValidatedEvent('setCameraPosition', cameraPositionSchema, ({ position, rotation }) => {
     camera.position.set(position.x, position.z, -position.y)
     camera.rotation.order = 'YZX'
 

--- a/web/src/layouts/gizmo/TransformComponent.tsx
+++ b/web/src/layouts/gizmo/TransformComponent.tsx
@@ -2,9 +2,9 @@ import React, { Suspense, useRef, useCallback, useState, useEffect } from 'react
 import { TransformControls } from '@react-three/drei'
 import { Mesh, MathUtils } from 'three'
 import { useRecoilValue } from 'recoil'
-import { useNuiEvent } from '../../hooks/useNuiEvent'
+import { useNuiValidatedEvent } from '../../hooks/useNuiValidatedEvent'
 import { fetchNui } from '../../utils/fetchNui'
-import { RotateSnapAtom, TranslateSnapAtom } from '../../atoms/object'
+import { RotateSnapAtom, transformEntityPayloadSchema, TranslateSnapAtom } from '../../atoms/object'
 
 export const TransformComponent = React.memo(({ space, mode, currentEntity, setCurrentEntity, onMouseUp, onMouseDown }: TransformComponent) => {
   const mesh = useRef<Mesh>(null!);
@@ -12,8 +12,8 @@ export const TransformComponent = React.memo(({ space, mode, currentEntity, setC
   const rotateSnap = useRecoilValue(RotateSnapAtom);
   const [shiftPressed, setShiftPressed] = useState(false);
 
-  useNuiEvent<TransformEntity>('setGizmoEntity', (entity: TransformEntity | undefined): void => {
-    setCurrentEntity(entity);
+  useNuiValidatedEvent('setGizmoEntity', transformEntityPayloadSchema, (entity): void => {
+    setCurrentEntity(entity as TransformEntity | undefined);
 
     // If entity is undefined or missing required data, clear the gizmo
     if (!entity || !entity.position || !entity.rotation) {

--- a/web/src/layouts/menu/components/HeaderGroup.tsx
+++ b/web/src/layouts/menu/components/HeaderGroup.tsx
@@ -4,9 +4,9 @@ import { TbLogout } from 'react-icons/tb'
 import { AiFillGithub } from 'react-icons/ai'
 import { FaDiscord } from 'react-icons/fa'
 import { SiKofi } from "react-icons/si"
-import { menuVisibilityAtom } from '../../../atoms/visibility'
+import { emptyEventSchema, menuVisibilityAtom } from '../../../atoms/visibility'
 import { Version } from '../../../atoms/version'
-import { useNuiEvent } from '../../../hooks/useNuiEvent'
+import { useNuiValidatedEvent } from '../../../hooks/useNuiValidatedEvent'
 import { fetchNui } from '../../../utils/fetchNui'
 import { useLocales } from '../../../providers/LocaleProvider'
 import { useExitListener } from '../../../hooks/useExitListener'
@@ -17,7 +17,7 @@ const HeaderGroup: React.FC<{data: Version}> = ({ data }) => {
   const { locale } = useLocales()
   const [visible, setVisible] = useRecoilState(menuVisibilityAtom)
 
-  useNuiEvent('setMenuVisible', () => setVisible(true))
+  useNuiValidatedEvent('setMenuVisible', emptyEventSchema, () => setVisible(true))
   useExitListener(setVisible)
 
   const [opened, setOpened] = useState(false)

--- a/web/src/layouts/menu/index.tsx
+++ b/web/src/layouts/menu/index.tsx
@@ -1,11 +1,11 @@
 import { AppShell, Box, createStyles, Transition } from '@mantine/core'
 import { useRecoilState, useSetRecoilState } from 'recoil'
 import { Route, Routes } from 'react-router-dom'
-import { useNuiEvent } from '../../hooks/useNuiEvent'
-import { menuVisibilityAtom } from '../../atoms/visibility'
-import { Version, versionAtom } from '../../atoms/version'
-import { interiorAtom, InteriorData, timecycleAtom, timecycleListAtom } from '../../atoms/interior'
-import { lastLocationsAtom, Location } from '../../atoms/location'
+import { useNuiValidatedEvent } from '../../hooks/useNuiValidatedEvent'
+import { menuVisibilityAtom, menuVisiblePayloadSchema } from '../../atoms/visibility'
+import { versionAtom } from '../../atoms/version'
+import { interiorAtom, interiorDataSchema, timecycleAtom, timecycleListAtom, timecycleOptionSchema } from '../../atoms/interior'
+import { lastLocationsAtom, locationSchema } from '../../atoms/location'
 import { positionAtom } from '../../atoms/position'
 import HeaderGroup from './components/HeaderGroup'
 import Nav from './components/Nav'
@@ -145,23 +145,23 @@ const Menu: React.FC = () => {
 
   useExitListener(setVisible)
 
-  useNuiEvent('setMenuVisible', (data: {version: Version, lastLocation: Location, position: string}) => {
+  useNuiValidatedEvent('setMenuVisible', menuVisiblePayloadSchema, (data) => {
     setVersion(data.version)
     setLastLocation(data.lastLocation)
     setPosition(data.position)
     setVisible(true)
   })
 
-  useNuiEvent('setLastLocation', (data: Location) => {
+  useNuiValidatedEvent('setLastLocation', locationSchema, (data) => {
     setLastLocation(data)
   })
 
-  useNuiEvent('setIntData', (data: InteriorData) => {
+  useNuiValidatedEvent('setIntData', interiorDataSchema, (data) => {
     setInteriorData(data)
     if (data.currentRoom !== undefined) setTimecycle(data.currentRoom.timecycle)
   })
 
-  useNuiEvent('setTimecycleList', (data: Array<{ label: string, value: string }>) => {
+  useNuiValidatedEvent('setTimecycleList', timecycleOptionSchema.array(), (data) => {
     setTimecycleList(data)
   })
 

--- a/web/src/layouts/menu/views/audio/index.tsx
+++ b/web/src/layouts/menu/views/audio/index.tsx
@@ -3,8 +3,8 @@ import { useDebouncedValue } from '@mantine/hooks'
 import { useEffect, useState } from 'react'
 import { BsClipboard, BsFillStopFill, BsPlayFill } from 'react-icons/bs'
 import { useRecoilState } from 'recoil'
-import { drawStaticEmittersAtom, radioStationsListAtom, StaticEmitter, staticEmittersDrawDistanceAtom, staticEmittersListAtom } from '../../../../atoms/audio'
-import { useNuiEvent } from '../../../../hooks/useNuiEvent'
+import { drawStaticEmittersAtom, radioStationsListAtom, selectItemSchema, staticEmitterSchema, staticEmittersDrawDistanceAtom, staticEmittersListAtom } from '../../../../atoms/audio'
+import { useNuiValidatedEvent } from '../../../../hooks/useNuiValidatedEvent'
 import { useLocales } from "../../../../providers/LocaleProvider"
 import { fetchNui } from '../../../../utils/fetchNui'
 import { setClipboard } from '../../../../utils/setClipboard'
@@ -18,12 +18,12 @@ const Audio: React.FC = () => {
     const [radioStationsList, setRadioStationsList] = useRecoilState(radioStationsListAtom)
     const [debouncedDistance] = useDebouncedValue(drawDistance, 200)
     
-    useNuiEvent('setClosestEmitter', (data: StaticEmitter) => {
+    useNuiValidatedEvent('setClosestEmitter', staticEmitterSchema, (data) => {
         setClosestEmitter(data)
         setRadioStation(data.radiostation)
     })
     
-    useNuiEvent('setRadioStationsList', (data: Array<{ label: string, value: string }>) => {
+    useNuiValidatedEvent('setRadioStationsList', selectItemSchema.array(), (data) => {
         setRadioStationsList(data)
     })
 

--- a/web/src/layouts/menu/views/home/index.tsx
+++ b/web/src/layouts/menu/views/home/index.tsx
@@ -8,9 +8,9 @@ import { RiHomeGearFill } from 'react-icons/ri'
 import { useRecoilState } from 'recoil'
 import { getInteriorData } from '../../../../atoms/interior'
 import { getLastLocation } from '../../../../atoms/location'
-import { positionAtom } from '../../../../atoms/position'
+import { playerCoordsSchema, positionAtom } from '../../../../atoms/position'
 import { worldFreezeTimeAtom } from '../../../../atoms/world'
-import { useNuiEvent } from '../../../../hooks/useNuiEvent'
+import { useNuiValidatedEvent } from '../../../../hooks/useNuiValidatedEvent'
 import { useLocales } from '../../../../providers/LocaleProvider'
 import { fetchNui } from '../../../../utils/fetchNui'
 import { setClipboard } from '../../../../utils/setClipboard'
@@ -26,7 +26,7 @@ const Home: React.FC = () => {
   const [timeFrozen, setTimeFrozen] = useRecoilState(worldFreezeTimeAtom)
   const [copiedCoords, setCopiedCoords] = useState(false)
 
-  useNuiEvent('playerCoords', (data: { coords: string, heading: string }) => {
+  useNuiValidatedEvent('playerCoords', playerCoordsSchema, (data) => {
     setCurrentCoords(data.coords)
     setCurrentHeading(data.heading)
   })

--- a/web/src/layouts/menu/views/interior/components/RoomsElement.tsx
+++ b/web/src/layouts/menu/views/interior/components/RoomsElement.tsx
@@ -7,10 +7,11 @@ import {
   interiorAtom,
   timecycleAtom,
   timecycleListAtom,
+  timecycleOptionSchema,
 } from "../../../../../atoms/interior";
 import { fetchNui } from "../../../../../utils/fetchNui";
 import { useLocales } from "../../../../../providers/LocaleProvider";
-import { useNuiEvent } from "../../../../../hooks/useNuiEvent";
+import { useNuiValidatedEvent } from "../../../../../hooks/useNuiValidatedEvent";
 
 // Memoized room info row
 const RoomInfoRow = memo(
@@ -71,8 +72,9 @@ const RoomsElement: React.FC = memo(() => {
     timecycleAtom
   );
 
-  useNuiEvent(
+  useNuiValidatedEvent(
     "setTimecycleList",
+    timecycleOptionSchema.array(),
     (data: Array<{ label: string; value: string }>) => {
       setTimecycleList(data);
     }

--- a/web/src/layouts/menu/views/locations/index.tsx
+++ b/web/src/layouts/menu/views/locations/index.tsx
@@ -1,14 +1,14 @@
 import { Accordion, Badge, Button, Center, Checkbox, Group, Pagination, Paper, ScrollArea, Stack, Text } from '@mantine/core'
 import { openModal } from '@mantine/modals'
 import CreateLocation from './components/modals/CreateLocation'
-import { Location, getSearchLocationInput, locationsActivePageAtom, locationCustomFilterAtom, locationsPageCountAtom, locationVanillaFilterAtom, locationsPageContentAtom } from '../../../../atoms/location'
+import { getSearchLocationInput, locationsActivePageAtom, locationCustomFilterAtom, locationsPageCountAtom, locationPageContentSchema, locationVanillaFilterAtom, locationsPageContentAtom } from '../../../../atoms/location'
 import LocationSearch from './components/LocationSearch'
 import { setClipboard } from '../../../../utils/setClipboard'
 import { useEffect, useState } from 'react'
 import RenameLocation from './components/modals/RenameLocation'
 import { useRecoilState } from 'recoil'
 import { fetchNui } from '../../../../utils/fetchNui'
-import { useNuiEvent } from '../../../../hooks/useNuiEvent'
+import { useNuiValidatedEvent } from '../../../../hooks/useNuiValidatedEvent'
 import DeleteLocation from './components/modals/DeleteLocation'
 import { useLocales } from '../../../../providers/LocaleProvider'
 
@@ -19,7 +19,7 @@ const Locations: React.FC = () => {
   const [pageCount, setPageCount] = useRecoilState(locationsPageCountAtom)
   const [activePage, setPage] = useRecoilState(locationsActivePageAtom)
 
-  useNuiEvent('setPageContent', (data: {type: string, content: Location[], maxPages: number}) => {
+  useNuiValidatedEvent('setPageContent', locationPageContentSchema, (data) => {
     if (data.type === 'locations') {
       setPageContent(data.content)
       setPageCount(data.maxPages)

--- a/web/src/layouts/menu/views/object/index.tsx
+++ b/web/src/layouts/menu/views/object/index.tsx
@@ -3,10 +3,10 @@ import { useRecoilState } from 'recoil'
 import { Accordion, ActionIcon, Button, Group, Paper, ScrollArea, Space, Text, TextInput } from '@mantine/core'
 import { openModal } from '@mantine/modals'
 import { MdLibraryAdd, MdDeleteForever } from 'react-icons/md'
-import { Entity, ObjectList, ObjectListAtom } from '../../../../atoms/object'
+import { Entity, ObjectListAtom, objectDataPayloadSchema, objectListPayloadSchema } from '../../../../atoms/object'
 import { fetchNui } from '../../../../utils/fetchNui'
 import AddEntity from './components/modals/AddEntity'
-import { useNuiEvent } from '../../../../hooks/useNuiEvent'
+import { useNuiValidatedEvent } from '../../../../hooks/useNuiValidatedEvent'
 import DeleteAllEntities from './components/modals/DeleteAllEntities'
 import { setClipboard } from '../../../../utils/setClipboard'
 import { useLocales } from '../../../../providers/LocaleProvider'
@@ -79,12 +79,12 @@ const Object: React.FC = () => {
     const [copiedCoords, setCopiedCoords] = useState<boolean>(false)
     const [copiedRotation, setCopiedRotation] = useState<boolean>(false)
 
-    useNuiEvent('setObjectList', (data: { entitiesList: ObjectList | null }) => {
+    useNuiValidatedEvent('setObjectList', objectListPayloadSchema, (data) => {
         if (data.entitiesList === null) return;
         setObjectList(data.entitiesList)
     })
 
-    useNuiEvent('setObjectData', (data: { entity: Entity }) => {
+    useNuiValidatedEvent('setObjectData', objectDataPayloadSchema, (data) => {
         if (!data.entity?.id) {
             setAccordionItem(null)
             return

--- a/web/src/layouts/menu/views/ped/index.tsx
+++ b/web/src/layouts/menu/views/ped/index.tsx
@@ -1,12 +1,12 @@
 import { Accordion, Button, Group, Paper, ScrollArea, Stack, Text, Image, Center, Pagination } from '@mantine/core'
 import { useEffect, useState} from 'react'
 import { useRecoilState, useSetRecoilState } from 'recoil'
-import { getSearchPedInput, PedProp, pedsActivePageAtom, pedsPageContentAtom, pedsPageCountAtom } from '../../../../atoms/ped'
+import { getSearchPedInput, pedPageContentSchema, pedsActivePageAtom, pedsPageContentAtom, pedsPageCountAtom } from '../../../../atoms/ped'
 import { displayImageAtom, imagePathAtom } from '../../../../atoms/imgPreview'
 import { setClipboard } from '../../../../utils/setClipboard'
 import PedSearch from './components/pedListSearch'
 import { fetchNui } from '../../../../utils/fetchNui'
-import { useNuiEvent } from '../../../../hooks/useNuiEvent'
+import { useNuiValidatedEvent } from '../../../../hooks/useNuiValidatedEvent'
 import { useLocales } from '../../../../providers/LocaleProvider'
 
 const Ped: React.FC = () => {
@@ -16,7 +16,7 @@ const Ped: React.FC = () => {
   const [pageCount, setPageCount] = useRecoilState(pedsPageCountAtom)
   const [activePage, setPage] = useRecoilState(pedsActivePageAtom)
 
-  useNuiEvent('setPageContent', (data: {type: string, content: PedProp[], maxPages: number}) => {
+  useNuiValidatedEvent('setPageContent', pedPageContentSchema, (data) => {
     if (data.type === 'peds') {
       setPageContent(data.content)
       setPageCount(data.maxPages)

--- a/web/src/layouts/menu/views/vehicle/index.tsx
+++ b/web/src/layouts/menu/views/vehicle/index.tsx
@@ -1,12 +1,12 @@
 import { Accordion, Button, Group, Paper, ScrollArea, Stack, Text, Image, Center, Pagination } from '@mantine/core'
 import { useEffect, useState} from 'react'
 import { useRecoilState, useSetRecoilState } from 'recoil'
-import { getSearchVehicleInput, vehiclesPageCountAtom, vehiclesActivePageAtom, vehiclesPageContentAtom, VehicleProp } from '../../../../atoms/vehicle'
+import { getSearchVehicleInput, vehiclesPageCountAtom, vehiclesActivePageAtom, vehiclesPageContentAtom, vehiclePageContentSchema } from '../../../../atoms/vehicle'
 import { displayImageAtom, imagePathAtom } from '../../../../atoms/imgPreview'
 import { setClipboard } from '../../../../utils/setClipboard'
 import VehicleSearch from './components/vehicleListSearch'
 import { fetchNui } from '../../../../utils/fetchNui'
-import { useNuiEvent } from '../../../../hooks/useNuiEvent'
+import { useNuiValidatedEvent } from '../../../../hooks/useNuiValidatedEvent'
 import { useLocales } from '../../../../providers/LocaleProvider'
 
 const Vehicle: React.FC = () => {
@@ -16,7 +16,7 @@ const Vehicle: React.FC = () => {
   const [pageCount, setPageCount] = useRecoilState(vehiclesPageCountAtom)
   const [activePage, setPage] = useRecoilState(vehiclesActivePageAtom)
 
-  useNuiEvent('setPageContent', (data: {type: string, content: VehicleProp[], maxPages: number}) => {
+  useNuiValidatedEvent('setPageContent', vehiclePageContentSchema, (data) => {
     if (data.type === 'vehicles') {
       setPageContent(data.content)
       setPageCount(data.maxPages)

--- a/web/src/layouts/menu/views/weapon/index.tsx
+++ b/web/src/layouts/menu/views/weapon/index.tsx
@@ -1,12 +1,12 @@
 import { Accordion, Button, Group, Paper, ScrollArea, Stack, Text, Image, Center, Pagination } from '@mantine/core'
 import { useEffect, useState} from 'react'
 import { useRecoilState, useSetRecoilState } from 'recoil'
-import { getSearchWeaponInput, weaponsPageCountAtom, weaponsActivePageAtom, weaponsPageContentAtom, WeaponProp } from '../../../../atoms/weapon'
+import { getSearchWeaponInput, weaponsPageCountAtom, weaponsActivePageAtom, weaponsPageContentAtom, weaponPageContentSchema } from '../../../../atoms/weapon'
 import { displayImageAtom, imagePathAtom } from '../../../../atoms/imgPreview'
 import { setClipboard } from '../../../../utils/setClipboard'
 import WeaponSearch from './components/weaponListSearch'
 import { fetchNui } from '../../../../utils/fetchNui'
-import { useNuiEvent } from '../../../../hooks/useNuiEvent'
+import { useNuiValidatedEvent } from '../../../../hooks/useNuiValidatedEvent'
 import { useLocales } from '../../../../providers/LocaleProvider'
 
 const Weapon: React.FC = () => {
@@ -16,7 +16,7 @@ const Weapon: React.FC = () => {
   const [pageCount, setPageCount] = useRecoilState(weaponsPageCountAtom)
   const [activePage, setPage] = useRecoilState(weaponsActivePageAtom)
 
-  useNuiEvent('setPageContent', (data: {type: string, content: WeaponProp[], maxPages: number}) => {
+  useNuiValidatedEvent('setPageContent', weaponPageContentSchema, (data) => {
     if (data.type === 'weapons') {
       setPageContent(data.content)
       setPageCount(data.maxPages)

--- a/web/src/layouts/menu/views/world/index.tsx
+++ b/web/src/layouts/menu/views/world/index.tsx
@@ -2,9 +2,9 @@ import { Text, Stack, SimpleGrid, Paper, Group, Select, NumberInput, Button, Spa
 import { AiOutlineClockCircle } from 'react-icons/ai'
 import { TiWeatherPartlySunny } from 'react-icons/ti'
 import { fetchNui } from '../../../../utils/fetchNui'
-import { useNuiEvent } from '../../../../hooks/useNuiEvent'
+import { useNuiValidatedEvent } from '../../../../hooks/useNuiValidatedEvent'
 import { useRecoilState } from 'recoil'
-import { worldFreezeTimeAtom, worldFreezeWeatherAtom, worldHourAtom, worldMinuteAtom, worldWeatherAtom } from '../../../../atoms/world'
+import { clockDataSchema, worldDataSchema, worldFreezeTimeAtom, worldFreezeWeatherAtom, worldHourAtom, worldMinuteAtom, worldWeatherAtom } from '../../../../atoms/world'
 import { useLocales } from '../../../../providers/LocaleProvider'
 
 const World: React.FC = () => {
@@ -15,13 +15,13 @@ const World: React.FC = () => {
   const [timeFrozen, setTimeFrozen] = useRecoilState(worldFreezeTimeAtom)
   const [weatherFrozen, setWeatherFrozen] = useRecoilState(worldFreezeWeatherAtom)
 
-  useNuiEvent('setWorldData', (data: any) => {
+  useNuiValidatedEvent('setWorldData', worldDataSchema, (data) => {
     setWeatherValue(data.weather)
     setHourValue(data.clock.hour)
     setMinuteValue(data.clock.minute)
   })
 
-  useNuiEvent('setClockData', (data: any) => {
+  useNuiValidatedEvent('setClockData', clockDataSchema, (data) => {
     setHourValue(data.hour)
     setMinuteValue(data.minute)
   })

--- a/web/src/providers/LocaleProvider.tsx
+++ b/web/src/providers/LocaleProvider.tsx
@@ -1,5 +1,6 @@
 import { Context, createContext, useContext, useEffect, useState } from 'react'
-import { useNuiEvent } from '../hooks/useNuiEvent'
+import { z } from 'zod'
+import { useNuiValidatedEvent } from '../hooks/useNuiValidatedEvent'
 import { fetchNui } from '../utils/fetchNui'
 import { debugData } from '../utils/debugData'
 
@@ -147,6 +148,8 @@ interface Locale {
   ui_room: string
   ui_radio_station: string
 }
+
+const localeSchema = z.record(z.string(), z.string()) as unknown as z.ZodSchema<Locale>
 
 debugData(
   [
@@ -458,7 +461,7 @@ const LocaleProvider: React.FC<{ children: React.ReactNode }> = ({ children }) =
     fetchNui('loadLocale')
   }, [])
 
-  useNuiEvent('setLocale', async (data: Locale) => setLocale(data))
+  useNuiValidatedEvent('setLocale', localeSchema, (data) => setLocale(data))
 
   return <LocaleCtx.Provider value={{ locale, setLocale }}>{children}</LocaleCtx.Provider>
 }


### PR DESCRIPTION
## What changed

This moves the web UI over to the validated NUI event hook everywhere it was previously consuming raw NUI messages directly.

The atom modules now own the Zod schemas for the payloads they represent, and the mounted listeners parse against those schemas before updating Recoil state. I also normalized a couple of shapes that the app already receives in practice, like interior flag values that can arrive as either numbers or strings.

## Why

A bad or partial NUI payload could previously flow straight into UI state and fail later in a component. Validating at the event boundary makes those failures easier to spot, keeps the state shape predictable, and gives us useful console output when the game/client side sends something unexpected.

## Notes

- The raw `useNuiEvent` hook still exists, but app-level consumers now go through `useNuiValidatedEvent`.
- TypeScript was bumped so the project can compile cleanly with the existing Zod 4 dependency.
- I left unrelated local workspace/tsconfig changes out of this PR.

## Validation

- `pnpm run build` passes.
- The build still reports the existing Vite eval warning, but it does not fail the build.